### PR TITLE
fix by kao mentioned in http://lifeinhex.com/net-scyllahide-and-heap_…

### DIFF
--- a/InjectorCLI/RemotePebHider.cpp
+++ b/InjectorCLI/RemotePebHider.cpp
@@ -179,7 +179,7 @@ void FixHeapFlag(HANDLE hProcess, DWORD_PTR heapBase)
 
 	if (ReadProcessMemory(hProcess, heapFlagsAddress, &heapFlags, sizeof(DWORD), 0))
 	{
-		heapFlags &= HEAP_GROWABLE;
+		heapFlags &= (HEAP_GROWABLE | HEAP_CREATE_ENABLE_EXECUTE);
 		WriteProcessMemory(hProcess, heapFlagsAddress, &heapFlags, sizeof(DWORD), 0);
 	}
 	if (ReadProcessMemory(hProcess, heapForceFlagsAddress, &heapForceFlags, sizeof(DWORD), 0))


### PR DESCRIPTION
…create_enable_execute (isn't a true fix though, it will probably cause older detection algorithms to trigger, so an option in Misc could be made for this)